### PR TITLE
보안 기능 고도화 - 환경변수의 사용

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,9 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/board
-    username: ldy
-    password: thisisTEST1!#%&
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
   jpa:
     defer-datasource-initialization: true
     hibernate.ddl-auto: create


### PR DESCRIPTION
application.yaml에 노출되면 안되는 각종 민감한 정보를 변수로 치환하여 보안을 높인다
하지만 커밋을 조회하면 이전에 노출된 값을 볼 수 있다
이를 근본적으로 해결하기 위해서는 이 저장소를 삭제 후 새로 올려야 한다.

This closes #81 